### PR TITLE
Update to (temporary) ugly AddressForm link

### DIFF
--- a/pages/components/Nav.tsx
+++ b/pages/components/Nav.tsx
@@ -64,7 +64,7 @@ export default function Nav({ color, light }: NavProps) {
                     </a>
 
                     <a
-                      href="https://addressform.io/form/toadztoolz"
+                      href="https://www.addressform.io/form/8d76bb5b-3898-43ee-990a-e37478c3c501"
                       target="_blank"
                       rel="noreferrer"
                     >

--- a/pages/components/Projects.tsx
+++ b/pages/components/Projects.tsx
@@ -14,7 +14,7 @@ const projects = [
     name: "Ideaz",
     description: "Submit your project or idea for the site!",
     imageUrl: "/projects/3.png",
-    link: "https://addressform.io/form/toadztoolz",
+    link: "https://www.addressform.io/form/8d76bb5b-3898-43ee-990a-e37478c3c501",
     class: "ideazbg",
   },
   {

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "redirects": [
     {
       "source": "/ideaz",
-      "destination": "https://addressform.io/form/toadztoolz"
+      "destination": "https://www.addressform.io/form/8d76bb5b-3898-43ee-990a-e37478c3c501"
     }
   ]
 }


### PR DESCRIPTION
My automated error alert service has notified me that a few people have been trying to visit addressform/form/toadztoolz which no longer exists (due to the updated URL format). 

This PR ensures that you only send people to the updated form. Note: This form is hosted on my account. I can pass along the responses and do a follow up PR once we get your account set up. 